### PR TITLE
fix(custom apps): make eternal jukebox reset text visible

### DIFF
--- a/custom-apps/eternal-jukebox/src/css/app.module.scss
+++ b/custom-apps/eternal-jukebox/src/css/app.module.scss
@@ -127,8 +127,8 @@
     }
 
     button {
-        background-color: var(--spice-text);
-        color: var(--spice-nav-active-text);
+        background-color: var(--spice-button);
+        color: var(--spice-text);
 
         padding: 0.5rem 1rem;
         border-style: none;


### PR DESCRIPTION
The text in the "Reset" button in Eternal Jukebox settings wasn't visible in some themes. Changed the color values to make it better.