### PR TITLE
feat(track-list): handle missing album art

### DIFF
--- a/custom-apps/better-local-files/src/components/shared/top-bar/top-bar-content.component.tsx
+++ b/custom-apps/better-local-files/src/components/shared/top-bar/top-bar-content.component.tsx
@@ -11,9 +11,9 @@ export type Props = {
 };
 
 export function TopBarContent(props: Readonly<Props>): JSX.Element {
-    const resizeHost = document.querySelector(
-        '.main-view-container__scroll-node',
-    );
+    const resizeHost =
+        document.querySelector('.Root__main-view .os-resize-observer-host') ??
+        document.querySelector('.main-view-container__scroll-node');
     if (!resizeHost) {
         throw new Error('Could not find resize host');
     }

--- a/custom-apps/better-local-files/src/components/shared/top-bar/top-bar-content.component.tsx
+++ b/custom-apps/better-local-files/src/components/shared/top-bar/top-bar-content.component.tsx
@@ -13,7 +13,7 @@ export type Props = {
 export function TopBarContent(props: Readonly<Props>): JSX.Element {
     const resizeHost =
         document.querySelector('.Root__main-view .os-resize-observer-host') ??
-        document.querySelector('.main-view-container__scroll-node');
+        document.querySelector('.Root__main-view .os-size-observer');
     if (!resizeHost) {
         throw new Error('Could not find resize host');
     }

--- a/custom-apps/better-local-files/src/components/shared/track-list/track-list-row-image-title.tsx
+++ b/custom-apps/better-local-files/src/components/shared/track-list/track-list-row-image-title.tsx
@@ -26,7 +26,9 @@ export function TrackListRowImageTitle(props: Readonly<Props>): JSX.Element {
         <>
             <img
                 loading="eager"
-                src={props.track.localTrack.album.images[0].url}
+                src={
+                    props.track.localTrack.album.images[0]?.url ?? imageFallback
+                }
                 className="main-image-image main-trackList-rowImage main-image-loaded"
                 width="40"
                 height="40"


### PR DESCRIPTION
`fix(top-bar): handle missing resize host for older versions`

Support older versions of Spotify when possible... and `scroll-node` is for viewport, not for resize host