### PR TITLE
fix(eternal-jukebox): fall back to equivalent track analysis

### DIFF
--- a/custom-apps/eternal-jukebox/src/models/jukebox.ts
+++ b/custom-apps/eternal-jukebox/src/models/jukebox.ts
@@ -5,10 +5,14 @@ import { Remixer } from '../helpers/remixer';
 import type { JukeboxSettings } from './jukebox-settings.js';
 import { JukeboxSongState } from './jukebox-song-state';
 
-import { getTrackAudioAnalysis } from '@shared/api/endpoints/tracks/get-audio-analysis';
 import type { AudioAnalysis } from '@shared/api/models/audio-analysis';
+import { searchTracks } from '@shared/graphQL/queries/search-tracks';
 import { Driver } from '../driver';
 import { SettingsService } from '../services/settings-service';
+
+const ALTERNATE_TRACK_SEARCH_LIMIT = 20;
+const MAX_ALTERNATE_TRACKS_TO_PROBE = 8;
+const MAX_DURATION_DIFFERENCE_MS = 1_500;
 
 export type StatsChangedEvent = {
     beatsPlayed: number;
@@ -154,15 +158,11 @@ export class Jukebox {
             return;
         }
 
-        let analysis: AudioAnalysis | null = null;
+        let analysis = await this.fetchUsableAnalysis(uri);
 
-        try {
-            analysis = await getTrackAudioAnalysis({ uri });
-        } catch {
-            // Do nothing
-        }
+        analysis ??= await this.findAlternateTrackAnalysis(currentTrack);
 
-        if (analysis === null || analysis.beats.length === 0) {
+        if (analysis === null) {
             this.disableWithError('No analysis available for this track.');
             return;
         }
@@ -199,6 +199,142 @@ export class Jukebox {
             }),
         );
         this.driver.start();
+    }
+
+    /**
+     * Fetch analysis while accounting for Spicetify returning HTTP error
+     * objects as successful values.
+     */
+    private async fetchUsableAnalysis(
+        uri: string,
+    ): Promise<AudioAnalysis | null> {
+        try {
+            const analysis: unknown = await Spicetify.getAudioData(uri);
+
+            if (this.isUsableAnalysis(analysis)) {
+                return analysis;
+            }
+        } catch {
+            // Try an equivalent catalog entry below.
+        }
+
+        return null;
+    }
+
+    /**
+     * Spotify sometimes replaces a track with a new catalog ID without
+     * copying its audio analysis. Find another release of the same recording
+     * and use its analysis when the title, artist, and duration all match.
+     */
+    private async findAlternateTrackAnalysis(
+        currentTrack: Spicetify.PlayerTrack,
+    ): Promise<AudioAnalysis | null> {
+        const artistName =
+            currentTrack.artists?.[0]?.name ??
+            currentTrack.metadata.artist_name ??
+            currentTrack.metadata['canvas.artist.name'];
+
+        if (!artistName) {
+            return null;
+        }
+
+        const escapeSearchValue = (value: string): string =>
+            value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+
+        try {
+            const result = await searchTracks({
+                searchTerm: `track:"${escapeSearchValue(currentTrack.name)}" artist:"${escapeSearchValue(artistName)}"`,
+                offset: 0,
+                limit: ALTERNATE_TRACK_SEARCH_LIMIT,
+                numberOfTopResults: 0,
+                includePreReleases: true,
+            });
+
+            const normalizedTitle = this.normalizeText(currentTrack.name);
+            const normalizedArtist = this.normalizeText(artistName);
+            const currentDuration = currentTrack.duration.milliseconds;
+
+            const candidates = result.searchV2.tracksV2.items
+                .map((item) => item.item.data)
+                .filter((track) => track.__typename === 'Track')
+                .filter((track) => track.uri !== currentTrack.uri)
+                .filter(
+                    (track) =>
+                        this.normalizeText(track.name) === normalizedTitle &&
+                        track.artists.items.some(
+                            (artist) =>
+                                this.normalizeText(artist.profile.name) ===
+                                normalizedArtist,
+                        ),
+                )
+                .filter(
+                    (track) =>
+                        Math.abs(
+                            track.duration.totalMilliseconds - currentDuration,
+                        ) <= MAX_DURATION_DIFFERENCE_MS,
+                )
+                .sort(
+                    (left, right) =>
+                        Math.abs(
+                            left.duration.totalMilliseconds - currentDuration,
+                        ) -
+                        Math.abs(
+                            right.duration.totalMilliseconds - currentDuration,
+                        ),
+                )
+                .slice(0, MAX_ALTERNATE_TRACKS_TO_PROBE);
+
+            for (const candidate of candidates) {
+                const analysis = await this.fetchUsableAnalysis(candidate.uri);
+
+                if (
+                    analysis !== null &&
+                    Math.abs(
+                        analysis.track.duration * 1_000 - currentDuration,
+                    ) <= MAX_DURATION_DIFFERENCE_MS
+                ) {
+                    Spicetify.showNotification(
+                        'Using analysis from an equivalent Spotify release.',
+                    );
+                    return analysis;
+                }
+            }
+        } catch (error) {
+            console.error(
+                '[Eternal Jukebox] Failed to find alternate track analysis',
+                error,
+            );
+        }
+
+        return null;
+    }
+
+    private normalizeText(value: string): string {
+        return value
+            .normalize('NFKD')
+            .replace(/\p{Diacritic}/gu, '')
+            .toLocaleLowerCase()
+            .replace(/[^a-z0-9]+/g, ' ')
+            .trim();
+    }
+
+    private isUsableAnalysis(value: unknown): value is AudioAnalysis {
+        if (typeof value !== 'object' || value === null) {
+            return false;
+        }
+
+        const analysis = value as Partial<AudioAnalysis>;
+
+        return (
+            analysis.track !== undefined &&
+            Array.isArray(analysis.bars) &&
+            Array.isArray(analysis.beats) &&
+            analysis.beats.length > 0 &&
+            Array.isArray(analysis.sections) &&
+            Array.isArray(analysis.segments) &&
+            analysis.segments.length > 0 &&
+            Array.isArray(analysis.tatums)
+        );
     }
 
     private disableWithError(error: string): void {


### PR DESCRIPTION
I was looping my favorite song with Eternal Jukebox and enjoying it. But later, when trying the same track, Eternal Jukebox just hung indefinitely.

Turns out that Spotify was returning a 404 in the background and the app didn't know how to handle it. The former is simply because Spotify has multiple IDs for a track since some tracks are released/distributed multiple times. This is a fix for the latter.

## Summary
- Validate the value returned by `Spicetify.getAudioData` before using it.
- When the current Spotify catalog ID has no audio analysis, search for equivalent releases with the same normalized title and primary artist.
- Only accept alternate tracks whose catalog and analysis durations are within 1.5 seconds of the playing track.
- Probe at most eight candidates and show a notification when alternate analysis is used.
- Fail cleanly when no usable analysis exists instead of leaving the Jukebox enabled without song state.

## Problem
`Spicetify.getAudioData` can resolve to an HTTP error object such as:

```js
{ code: 404, message: "Failed to fetch" }
```

Because that object is truthy, Eternal Jukebox treated it as valid analysis and then crashed while reading `analysis.beats.length`. Spotify can also assign a new catalog ID to an existing recording without copying its audio analysis, even when another release of the same recording still has valid beat and segment data.

## Solution
The Jukebox now validates all arrays required by the remixer. If the current ID has no usable analysis, it searches Spotify for exact title/artist matches, ranks candidates by duration difference, and accepts only tightly duration-matched analysis.

## Testing
- TypeScript check passes: `tsc --noEmit`
- Production custom-app build succeeds: `spicetify-creator --out=dist --minify`
- Reproduced with `spotify:track:6st8aj6PmtqGctnLAat95M` (`Life Goes On` by The Sundays), whose direct analysis request returns `404`
- Confirmed the fallback loads 464 beats and renders the Jukebox graph
- Confirmed a normally analyzed control track still uses the direct path and returns 833 beats / 1,095 segments
